### PR TITLE
Fix external port configuration for Flask app

### DIFF
--- a/app.py
+++ b/app.py
@@ -543,4 +543,6 @@ def e404(e): return render_template("error.html", code=404, message="Not Found")
 if __name__=="__main__":
     os.makedirs(MEDIA_DIR, exist_ok=True)
     init_db()
-    app.run(debug=True)
+    # Bind to 0.0.0.0 so Replit and other PaaS providers can access the port
+    port = int(os.environ.get("PORT", 5000))
+    app.run(host="0.0.0.0", port=port, debug=True)


### PR DESCRIPTION
## Summary
- Allow Flask app to listen on `0.0.0.0` and respect `PORT` env var so platforms like Replit expose the server port

## Testing
- `python -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_e_68ad986a3e2c83288156c98f151c70ce