### PR TITLE
Add site-wide AI chatbot

### DIFF
--- a/app.py
+++ b/app.py
@@ -534,6 +534,29 @@ def manager_notifications():
     db.close()
     return render_template("manager/notifications.html", notes=notes)
 
+# ----------------- AI chatbot
+@app.route("/chatbot", methods=["POST"])
+def chatbot():
+    data = request.get_json() or {}
+    message = (data.get("message") or "").strip()
+    if not message:
+        return {"reply": "Please say something."}
+    key = get_setting("openai_key") or os.environ.get("OPENAI_API_KEY")
+    if not key:
+        return {"reply": "AI not configured."}
+    try:
+        from openai import OpenAI
+        client = OpenAI(api_key=key)
+        resp = client.chat.completions.create(
+            model="gpt-3.5-turbo",
+            messages=[{"role": "user", "content": message}],
+            max_tokens=200,
+        )
+        reply = resp.choices[0].message["content"].strip()
+    except Exception as e:
+        reply = f"Error: {e}"
+    return {"reply": reply}
+
 # ----------------- errors
 @app.errorhandler(403)
 def e403(e): return render_template("error.html", code=403, message="Forbidden"), 403

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
-﻿Flask>=3.0,<4
+Flask>=3.0,<4
 gunicorn>=21,<22
+openai>=1.0.0

--- a/templates/layout.html
+++ b/templates/layout.html
@@ -67,5 +67,33 @@
   <footer class="mt-16 py-8 text-center text-sm text-base-muted">
     © {{ 2025 }} CareWhistle — Independent whistleblowing service. <span class="mx-2">•</span> help@carewhistle.app
   </footer>
+
+  <div id="chatbot-box" class="fixed bottom-20 right-4 w-80 max-w-full bg-white border rounded-lg shadow-lg hidden flex-col h-96">
+    <div id="chatbot-log" class="p-2 flex-1 overflow-y-auto text-sm"></div>
+    <form id="chatbot-form" class="flex border-t">
+      <input id="chatbot-input" class="flex-1 p-2 text-sm" placeholder="Ask a question..." />
+      <button class="px-3 text-white bg-neon-blue">Send</button>
+    </form>
+  </div>
+  <button id="chatbot-toggle" class="fixed bottom-4 right-4 w-12 h-12 rounded-full bg-neon-blue text-white shadow-lg">💬</button>
+  <script>
+    const toggle=document.getElementById('chatbot-toggle');
+    const box=document.getElementById('chatbot-box');
+    const form=document.getElementById('chatbot-form');
+    const input=document.getElementById('chatbot-input');
+    const log=document.getElementById('chatbot-log');
+    toggle.addEventListener('click',()=>{box.classList.toggle('hidden'); input.focus();});
+    form.addEventListener('submit', async (e)=>{
+      e.preventDefault();
+      const msg=input.value.trim();
+      if(!msg) return;
+      log.innerHTML+=`<div class="text-right mb-1">${msg}</div>`;
+      input.value='';
+      const r=await fetch('/chatbot',{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify({message:msg})});
+      const data=await r.json();
+      log.innerHTML+=`<div class="text-left mb-1 text-neon-blue">${data.reply}</div>`;
+      log.scrollTop=log.scrollHeight;
+    });
+  </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- add `/chatbot` endpoint using OpenAI for responses
- inject floating chat widget into base layout for access on every page
- include OpenAI client library

## Testing
- `pip install "openai>=1.0.0"`
- `python -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_e_68ad9d69e52c832881fd2245af5fef17