### PR TITLE
Remove BOM from HTML templates

### DIFF
--- a/templates/admin/companies.html
+++ b/templates/admin/companies.html
@@ -1,4 +1,4 @@
-﻿{% extends "admin/frame.html" %}{% block admin %}
+{% extends "admin/frame.html" %}{% block admin %}
 <h2 class="text-2xl font-extrabold mb-4">Companies</h2>
 <form method="post" class="bg-white rounded-xl p-4 border shadow-glass grid md:grid-cols-3 gap-4 mb-4">
   <div><label class="block text-sm mb-1">Name</label><input name="name" class="w-full rounded-lg border px-3 py-2" required></div>

--- a/templates/admin/company_dashboard.html
+++ b/templates/admin/company_dashboard.html
@@ -1,4 +1,4 @@
-﻿{% extends "admin/frame.html" %}{% block admin %}
+{% extends "admin/frame.html" %}{% block admin %}
 <h2 class="text-2xl font-extrabold mb-2">{{ company.name }}</h2>
 <div class="text-sm text-base-muted mb-4">Company Code: <code>{{ company.code }}</code></div>
 <div class="grid md:grid-cols-3 gap-4">

--- a/templates/admin/dashboard.html
+++ b/templates/admin/dashboard.html
@@ -1,4 +1,4 @@
-﻿{% extends "admin/frame.html" %}{% block admin %}
+{% extends "admin/frame.html" %}{% block admin %}
 <h2 class="text-2xl font-extrabold mb-4">Overview</h2>
 <div class="grid md:grid-cols-4 gap-4">
   <div class="bg-white rounded-xl p-4 border shadow-glass"><div class="text-base-muted">New</div><div class="text-3xl font-extrabold">{{ stats.new or 0 }}</div></div>

--- a/templates/admin/frame.html
+++ b/templates/admin/frame.html
@@ -1,4 +1,4 @@
-﻿{% extends "layout.html" %}{% block body %}
+{% extends "layout.html" %}{% block body %}
 <div class="max-w-7xl mx-auto px-4 py-8 grid lg:grid-cols-[240px_1fr] gap-6">
   <aside class="bg-white rounded-xl p-4 border shadow-glass h-max">
     <div class="font-extrabold mb-2">CareWhistle Admin</div>

--- a/templates/admin/media.html
+++ b/templates/admin/media.html
@@ -1,4 +1,4 @@
-﻿{% extends "admin/frame.html" %}{% block admin %}
+{% extends "admin/frame.html" %}{% block admin %}
 <h2 class="text-2xl font-extrabold mb-4">Media</h2>
 <form method="post" enctype="multipart/form-data" class="bg-white rounded-xl p-4 border shadow-glass flex items-end gap-3 mb-4">
   <div><label class="block text-sm mb-1">Upload file</label><input type="file" name="file" class="block"></div>

--- a/templates/admin/notifications.html
+++ b/templates/admin/notifications.html
@@ -1,4 +1,4 @@
-﻿{% extends "admin/frame.html" %}{% block admin %}
+{% extends "admin/frame.html" %}{% block admin %}
 <h2 class="text-2xl font-extrabold mb-4">Notifications</h2>
 <div class="bg-white rounded-xl p-4 border shadow-glass">
   {% if notes|length==0 %}<div class="text-base-muted">No new notifications.</div>{% endif %}

--- a/templates/admin/report_detail.html
+++ b/templates/admin/report_detail.html
@@ -1,4 +1,4 @@
-﻿{% extends "admin/frame.html" %}{% block admin %}
+{% extends "admin/frame.html" %}{% block admin %}
 <h2 class="text-2xl font-extrabold mb-2">Report #{{ r.id }}</h2>
 <div class="text-sm text-base-muted mb-4">Company Code: <code>{{ r.company_code }}</code> • Category: {{ r.category }} • Status: <b>{{ r.status }}</b> • Created: {{ r.created_at }}</div>
 <div class="grid lg:grid-cols-2 gap-4">

--- a/templates/admin/reports.html
+++ b/templates/admin/reports.html
@@ -1,4 +1,4 @@
-﻿{% extends "admin/frame.html" %}{% block admin %}
+{% extends "admin/frame.html" %}{% block admin %}
 <h2 class="text-2xl font-extrabold mb-4">Reports</h2>
 <form class="bg-white rounded-xl p-4 border shadow-glass grid md:grid-cols-5 gap-3 mb-4" method="get">
   <input class="rounded-lg border px-3 py-2" name="q" value="{{ q or '' }}" placeholder="Search by subject">

--- a/templates/admin/settings.html
+++ b/templates/admin/settings.html
@@ -1,4 +1,4 @@
-﻿{% extends "admin/frame.html" %}{% block admin %}
+{% extends "admin/frame.html" %}{% block admin %}
 <h2 class="text-2xl font-extrabold mb-4">Settings</h2>
 <form method="post" class="bg-white rounded-xl p-4 border shadow-glass grid md:grid-cols-2 gap-4">
   <div><label class="block text-sm mb-1">SMTP URL</label><input name="smtp_url" value="{{ settings.smtp_url or '' }}" class="w-full rounded-lg border px-3 py-2"></div>

--- a/templates/admin/users.html
+++ b/templates/admin/users.html
@@ -1,4 +1,4 @@
-﻿{% extends "admin/frame.html" %}{% block admin %}
+{% extends "admin/frame.html" %}{% block admin %}
 <h2 class="text-2xl font-extrabold mb-4">Users</h2>
 <form method="post" class="bg-white rounded-xl p-4 border shadow-glass grid md:grid-cols-3 gap-4 mb-4">
   <div><label class="block text-sm mb-1">Email</label><input name="email" required class="w-full rounded-lg border px-3 py-2"></div>

--- a/templates/error.html
+++ b/templates/error.html
@@ -1,4 +1,4 @@
-﻿{% extends "layout.html" %}{% block body %}
+{% extends "layout.html" %}{% block body %}
 <section class="max-w-xl mx-auto px-4 py-10">
   <div class="bg-white rounded-2xl p-6 border shadow-glass">
     <h2 class="text-2xl font-extrabold mb-2">Error {{ code }}</h2>

--- a/templates/follow.html
+++ b/templates/follow.html
@@ -1,4 +1,4 @@
-﻿{% extends "layout.html" %}{% block body %}
+{% extends "layout.html" %}{% block body %}
 <section class="max-w-xl mx-auto px-4 py-10">
   <h2 class="text-3xl font-extrabold mb-4">Case Portal</h2>
   <form method="post" class="bg-white rounded-2xl p-6 border shadow-glass grid gap-4">

--- a/templates/follow_thread.html
+++ b/templates/follow_thread.html
@@ -1,4 +1,4 @@
-﻿{% extends "layout.html" %}{% block body %}
+{% extends "layout.html" %}{% block body %}
 <section class="max-w-3xl mx-auto px-4 py-10">
   <h2 class="text-2xl font-extrabold mb-3">Your case</h2>
   <div class="bg-white rounded-2xl p-6 border shadow-glass">

--- a/templates/how.html
+++ b/templates/how.html
@@ -1,4 +1,4 @@
-﻿{% extends "layout.html" %}{% block body %}
+{% extends "layout.html" %}{% block body %}
 <section class="max-w-4xl mx-auto px-4 py-10">
   <h2 class="text-3xl font-extrabold mb-4">How our whistleblowing service works</h2>
   <div class="prose max-w-none">

--- a/templates/index.html
+++ b/templates/index.html
@@ -1,4 +1,4 @@
-﻿{% extends "layout.html" %}{% block body %}
+{% extends "layout.html" %}{% block body %}
 <section class="max-w-7xl mx-auto px-4 py-10">
   <div class="grid lg:grid-cols-2 gap-8 items-center">
     <div>

--- a/templates/login.html
+++ b/templates/login.html
@@ -1,4 +1,4 @@
-﻿{% extends "layout.html" %}{% block body %}
+{% extends "layout.html" %}{% block body %}
 <section class="max-w-md mx-auto px-4 py-10">
   <h2 class="text-3xl font-extrabold mb-4">Login</h2>
   <form method="post" class="bg-white rounded-xl p-6 border shadow-glass grid gap-4">

--- a/templates/manager/frame.html
+++ b/templates/manager/frame.html
@@ -1,4 +1,4 @@
-﻿{% extends "layout.html" %}{% block body %}
+{% extends "layout.html" %}{% block body %}
 <div class="max-w-7xl mx-auto px-4 py-8 grid lg:grid-cols-[240px_1fr] gap-6">
   <aside class="bg-white rounded-xl p-4 border shadow-glass h-max">
     <div class="font-extrabold mb-2">Manager</div>

--- a/templates/manager/messages.html
+++ b/templates/manager/messages.html
@@ -1,4 +1,4 @@
-﻿{% extends "manager/frame.html" %}{% block manager %}
+{% extends "manager/frame.html" %}{% block manager %}
 <h2 class="text-2xl font-extrabold mb-4">Messages</h2>
 <div class="bg-white rounded-xl p-4 border shadow-glass">
   <table class="w-full text-sm">

--- a/templates/manager/messages_thread.html
+++ b/templates/manager/messages_thread.html
@@ -1,4 +1,4 @@
-﻿{% extends "manager/frame.html" %}{% block manager %}
+{% extends "manager/frame.html" %}{% block manager %}
 <h2 class="text-2xl font-extrabold mb-3">Report #{{ rid }} — Messages with Admin</h2>
 <div class="bg-white rounded-xl p-4 border shadow-glass">
   <div class="text-sm text-base-muted mb-2">Company Code: <code>{{ company_code }}</code></div>

--- a/templates/manager/notifications.html
+++ b/templates/manager/notifications.html
@@ -1,4 +1,4 @@
-﻿{% extends "manager/frame.html" %}{% block manager %}
+{% extends "manager/frame.html" %}{% block manager %}
 <h2 class="text-2xl font-extrabold mb-4">Notifications</h2>
 <div class="bg-white rounded-xl p-4 border shadow-glass">
   {% if notes|length==0 %}<div class="text-base-muted">No new notifications.</div>{% endif %}

--- a/templates/manager/overview.html
+++ b/templates/manager/overview.html
@@ -1,4 +1,4 @@
-﻿{% extends "manager/frame.html" %}{% block manager %}
+{% extends "manager/frame.html" %}{% block manager %}
 <h2 class="text-2xl font-extrabold mb-4">Overview</h2>
 <div class="grid md:grid-cols-3 gap-4">
   <div class="bg-white rounded-xl p-4 border shadow-glass"><div class="text-base-muted">Assigned</div><div class="text-3xl font-extrabold">{{ stats.assigned or 0 }}</div></div>

--- a/templates/pricing.html
+++ b/templates/pricing.html
@@ -1,4 +1,4 @@
-﻿{% extends "layout.html" %}{% block body %}
+{% extends "layout.html" %}{% block body %}
 <section class="max-w-4xl mx-auto px-4 py-10">
   <h2 class="text-3xl font-extrabold mb-4">Plans & Pricing</h2>
   <div class="bg-white rounded-2xl p-8 border shadow-glass">

--- a/templates/report.html
+++ b/templates/report.html
@@ -1,4 +1,4 @@
-﻿{% extends "layout.html" %}{% block body %}
+{% extends "layout.html" %}{% block body %}
 <section class="max-w-3xl mx-auto px-4 py-10">
   <h2 class="text-3xl font-extrabold mb-4">Make a Report</h2>
   <form method="post" class="bg-white rounded-2xl p-6 border shadow-glass grid gap-4">

--- a/templates/report_success.html
+++ b/templates/report_success.html
@@ -1,4 +1,4 @@
-﻿{% extends "layout.html" %}{% block body %}
+{% extends "layout.html" %}{% block body %}
 <section class="max-w-xl mx-auto px-4 py-10">
   <div class="bg-white rounded-2xl p-6 border shadow-glass">
     <h2 class="text-2xl font-extrabold mb-2">Report submitted</h2>


### PR DESCRIPTION
## Summary
- drop UTF-8 BOM markers from all HTML templates to prevent stray characters and rendering issues

## Testing
- `python - <<'PY'
from flask import Flask
from jinja2 import Environment, FileSystemLoader
env = Environment(loader=FileSystemLoader('templates'), autoescape=True)
for tpl in env.list_templates():
    env.get_template(tpl)
PY`
- `python -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_e_68ada44979d08328a6edd6c3ff41e6cb