### PR TITLE
Configure Flask deployment settings

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,12 @@
+__pycache__
+*.pyc
+*.pyo
+*.pyd
+*.db
+*.sqlite3
+*.log
+.git
+.gitignore
+.env
+carewhistle.db
+media

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,19 @@
+# Use official Python runtime as a parent image
+FROM python:3.11-slim
+
+# Set working directory
+WORKDIR /app
+
+# Install dependencies
+COPY requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
+
+# Copy the rest of the application code
+COPY . .
+
+# Expose port 5000 and set default port environment variable
+ENV PORT=5000
+EXPOSE 5000
+
+# Run the application with gunicorn, honoring the PORT environment variable
+CMD ["sh", "-c", "gunicorn -w 3 -k gthread --threads 4 -b 0.0.0.0:${PORT} app:app"]

--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,1 @@
-﻿web: gunicorn -w 3 -k gthread --threads 4 -b 0.0.0.0:$PORT app:app
+web: gunicorn -w 3 -k gthread --threads 4 -b 0.0.0.0:${PORT:-5000} app:app

--- a/app.py
+++ b/app.py
@@ -543,4 +543,6 @@ def e404(e): return render_template("error.html", code=404, message="Not Found")
 if __name__=="__main__":
     os.makedirs(MEDIA_DIR, exist_ok=True)
     init_db()
-    app.run(debug=True)
+    debug = os.environ.get("FLASK_DEBUG", "0") == "1"
+    port = int(os.environ.get("PORT", 5000))
+    app.run(host="0.0.0.0", port=port, debug=debug)


### PR DESCRIPTION
## Summary
- run Flask app on 0.0.0.0:5000 with debug controlled by FLASK_DEBUG
- update Procfile and Dockerfile to bind Gunicorn to configurable PORT
- add .dockerignore to slim Docker builds

## Testing
- `python -m py_compile app.py`
- `python -c 'import app'`


------
https://chatgpt.com/codex/tasks/task_e_68ad969b68088328819862efd0c48e43