### PR TITLE
Add site-wide AI chatbot

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
-﻿Flask>=3.0,<4
+Flask>=3.0,<4
 gunicorn>=21,<22
+openai>=1.0.0

--- a/templates/chatbot.html
+++ b/templates/chatbot.html
@@ -1,0 +1,27 @@
+<div id="chatbot-box" class="fixed bottom-20 right-4 w-80 max-w-full bg-white border rounded-lg shadow-lg hidden flex-col h-96">
+  <div id="chatbot-log" class="p-2 flex-1 overflow-y-auto text-sm"></div>
+  <form id="chatbot-form" class="flex border-t">
+    <input id="chatbot-input" class="flex-1 p-2 text-sm" placeholder="Ask a question..." />
+    <button class="px-3 text-white bg-neon-blue">Send</button>
+  </form>
+</div>
+<button id="chatbot-toggle" class="fixed bottom-4 right-4 w-12 h-12 rounded-full bg-neon-blue text-white shadow-lg">💬</button>
+<script>
+  const toggle=document.getElementById('chatbot-toggle');
+  const box=document.getElementById('chatbot-box');
+  const form=document.getElementById('chatbot-form');
+  const input=document.getElementById('chatbot-input');
+  const log=document.getElementById('chatbot-log');
+  toggle.addEventListener('click',()=>{box.classList.toggle('hidden'); input.focus();});
+  form.addEventListener('submit', async (e)=>{
+    e.preventDefault();
+    const msg=input.value.trim();
+    if(!msg) return;
+    log.innerHTML+=`<div class="text-right mb-1">${msg}</div>`;
+    input.value='';
+    const r=await fetch('/chatbot',{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify({message:msg})});
+    const data=await r.json();
+    log.innerHTML+=`<div class="text-left mb-1 text-neon-blue">${data.reply}</div>`;
+    log.scrollTop=log.scrollHeight;
+  });
+</script>

--- a/templates/layout.html
+++ b/templates/layout.html
@@ -65,7 +65,9 @@
   {% block body %}{% endblock %}
 
   <footer class="mt-16 py-8 text-center text-sm text-base-muted">
-    © {{ 2025 }} CareWhistle — Independent whistleblowing service. <span class="mx-2">•</span> help@carewhistle.app
+    &copy; {{ current_year }} CareWhistle — Independent whistleblowing service. <span class="mx-2">•</span> help@carewhistle.app
   </footer>
+
+  {% include 'chatbot.html' %}
 </body>
 </html>


### PR DESCRIPTION
## Summary
- add `/chatbot` endpoint using OpenAI for responses
- include floating chat widget partial in base layout for access on every page
- inject current year into templates via context processor and tidy footer markup

## Testing
- `pip install -r requirements.txt`
- `python -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_e_68ad9d69e52c832881fd2245af5fef17