### PR TITLE
Add Stripe and PayPal checkout

### DIFF
--- a/.env
+++ b/.env
@@ -1,0 +1,4 @@
+SECRET_KEY=dev-secret-change-me
+STRIPE_SECRET_KEY=sk_test_replace_with_real
+PAYPAL_CLIENT_ID=replace_with_real
+PAYPAL_CLIENT_SECRET=replace_with_real

--- a/app.py
+++ b/app.py
@@ -1,7 +1,16 @@
-﻿import os, sqlite3, secrets, random
+import os
+import sqlite3
+import secrets
+import random
 from datetime import datetime, timezone
 from functools import wraps
+
 from flask import Flask, render_template, request, redirect, url_for, session, flash, abort, send_from_directory
+from dotenv import load_dotenv
+import stripe
+import paypalrestsdk
+
+load_dotenv()
 
 APP_NAME = "CareWhistle v78-lite"
 BASE_DIR = os.path.dirname(__file__)
@@ -18,6 +27,16 @@ app.config.update(
     SESSION_COOKIE_SAMESITE="Lax",
     MAX_CONTENT_LENGTH=25*1024*1024
 )
+
+# --- Stripe ---
+stripe.api_key = os.getenv("STRIPE_SECRET_KEY", "sk_test_dummy")
+
+# --- PayPal ---
+paypalrestsdk.configure({
+    "mode": "sandbox",  # change to live when ready
+    "client_id": os.getenv("PAYPAL_CLIENT_ID", "dummy"),
+    "client_secret": os.getenv("PAYPAL_CLIENT_SECRET", "dummy")
+})
 
 def now_iso(): return datetime.now(timezone.utc).isoformat()
 
@@ -160,6 +179,59 @@ def how(): return render_template("how.html", title="How it works")
 
 @app.route("/pricing")
 def pricing(): return render_template("pricing.html", title="Plans & Pricing")
+
+
+@app.route("/checkout/stripe", methods=["POST"])
+def checkout_stripe():
+    try:
+        session_stripe = stripe.checkout.Session.create(
+            payment_method_types=["card"],
+            line_items=[{
+                "price_data": {
+                    "currency": "gbp",
+                    "unit_amount": 15000,
+                    "product_data": {"name": "CareWhistle Annual Plan"},
+                },
+                "quantity": 1,
+            }],
+            mode="payment",
+            success_url=url_for("pricing", _external=True) + "?success=1",
+            cancel_url=url_for("pricing", _external=True) + "?canceled=1",
+        )
+        return redirect(session_stripe.url, code=303)
+    except Exception as e:
+        flash("Stripe error: " + str(e), "danger")
+        return redirect(url_for("pricing"))
+
+
+@app.route("/checkout/paypal", methods=["POST"])
+def checkout_paypal():
+    payment = paypalrestsdk.Payment({
+        "intent": "sale",
+        "payer": {"payment_method": "paypal"},
+        "redirect_urls": {
+            "return_url": url_for("pricing", _external=True) + "?paypal=success",
+            "cancel_url": url_for("pricing", _external=True) + "?paypal=canceled"
+        },
+        "transactions": [{
+            "item_list": {"items": [{
+                "name": "CareWhistle Annual Plan",
+                "sku": "cw-plan",
+                "price": "150.00",
+                "currency": "GBP",
+                "quantity": 1
+            }]},
+            "amount": {"total": "150.00", "currency": "GBP"},
+            "description": "Annual subscription"
+        }]
+    })
+
+    if payment.create():
+        for link in payment.links:
+            if link.method == "REDIRECT":
+                return redirect(link.href)
+    flash("PayPal error: " + str(payment.error), "danger")
+    return redirect(url_for("pricing"))
 
 def make_captcha():
     a,b = random.randint(1,9), random.randint(1,9)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,5 @@
-﻿Flask>=3.0,<4
+Flask>=3.0,<4
 gunicorn>=21,<22
+python-dotenv
+stripe
+paypalrestsdk

--- a/templates/pricing.html
+++ b/templates/pricing.html
@@ -1,4 +1,5 @@
-﻿{% extends "layout.html" %}{% block body %}
+{% extends "layout.html" %}
+{% block body %}
 <section class="max-w-4xl mx-auto px-4 py-10">
   <h2 class="text-3xl font-extrabold mb-4">Plans & Pricing</h2>
   <div class="bg-white rounded-2xl p-8 border shadow-glass">
@@ -7,6 +8,14 @@
       <li>Unlimited report recipients</li><li>Anonymous reporting</li><li>Separate chats per report</li>
       <li>Manager & Admin portals</li><li>Media uploads</li><li>ISO-friendly, GDPR-aware</li>
     </ul>
+    <div class="mt-6 flex gap-4">
+      <form action="{{ url_for('checkout_stripe') }}" method="post">
+        <button class="btn success">💳 Pay with Stripe</button>
+      </form>
+      <form action="{{ url_for('checkout_paypal') }}" method="post">
+        <button class="btn secondary">🅿️ Pay with PayPal</button>
+      </form>
+    </div>
   </div>
 </section>
 {% endblock %}


### PR DESCRIPTION
## Summary
- reorganize payment SDK imports and configuration in the Flask app
- restore pricing template layout and include Stripe and PayPal buttons
- split top-level imports onto separate lines to resolve conflicts

## Testing
- `python -m pip install -r requirements.txt`
- `python -m py_compile app.py`
- `python -m flask --app app routes`


------
https://chatgpt.com/codex/tasks/task_e_68ad9f728c2083289fa910e1fb51e4db