### PR TITLE
Add Stripe and PayPal checkout

### DIFF
--- a/.env
+++ b/.env
@@ -1,0 +1,4 @@
+SECRET_KEY=dev-secret-change-me
+STRIPE_SECRET_KEY=sk_test_replace_with_real
+PAYPAL_CLIENT_ID=replace_with_real
+PAYPAL_CLIENT_SECRET=replace_with_real

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,5 @@
-﻿Flask>=3.0,<4
+Flask>=3.0,<4
 gunicorn>=21,<22
+python-dotenv
+stripe
+paypalrestsdk

--- a/templates/pricing.html
+++ b/templates/pricing.html
@@ -1,4 +1,5 @@
-﻿{% extends "layout.html" %}{% block body %}
+{% extends "layout.html" %}
+{% block body %}
 <section class="max-w-4xl mx-auto px-4 py-10">
   <h2 class="text-3xl font-extrabold mb-4">Plans & Pricing</h2>
   <div class="bg-white rounded-2xl p-8 border shadow-glass">
@@ -7,6 +8,14 @@
       <li>Unlimited report recipients</li><li>Anonymous reporting</li><li>Separate chats per report</li>
       <li>Manager & Admin portals</li><li>Media uploads</li><li>ISO-friendly, GDPR-aware</li>
     </ul>
+    <div class="mt-6 flex gap-4">
+      <form action="{{ url_for('checkout_stripe') }}" method="post">
+        <button class="btn success">💳 Pay with Stripe</button>
+      </form>
+      <form action="{{ url_for('checkout_paypal') }}" method="post">
+        <button class="btn secondary">🅿️ Pay with PayPal</button>
+      </form>
+    </div>
   </div>
 </section>
 {% endblock %}


### PR DESCRIPTION
## Summary
- reorganize payment SDK imports and configuration in the Flask app
- restore pricing template layout and include Stripe and PayPal buttons
- split top-level imports onto separate lines to resolve conflicts
- group imports by standard library and third-party packages

## Testing
- `python -m pip install -r requirements.txt`
- `python -m py_compile app.py`
- `python -m flask --app app routes`


------
https://chatgpt.com/codex/tasks/task_e_68ad9f728c2083289fa910e1fb51e4db