### PR TITLE
Enhance chatbot with session history and error handling

### DIFF
--- a/templates/chatbot.html
+++ b/templates/chatbot.html
@@ -19,9 +19,17 @@
     if(!msg) return;
     log.innerHTML+=`<div class="text-right mb-1">${msg}</div>`;
     input.value='';
-    const r=await fetch('/chatbot',{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify({message:msg})});
-    const data=await r.json();
-    log.innerHTML+=`<div class="text-left mb-1 text-neon-blue">${data.reply}</div>`;
+    try {
+      const r=await fetch('/chatbot',{
+        method:'POST',
+        headers:{'Content-Type':'application/json'},
+        body:JSON.stringify({message:msg})
+      });
+      const data=await r.json();
+      log.innerHTML+=`<div class="text-left mb-1 text-neon-blue">${data.reply}</div>`;
+    } catch(err){
+      log.innerHTML+=`<div class="text-left mb-1 text-red-600">Error: ${err}</div>`;
+    }
     log.scrollTop=log.scrollHeight;
   });
 </script>


### PR DESCRIPTION
## Summary
- Maintain per-session conversation history for the AI chatbot and persist replies
- Gracefully handle missing OpenAI keys and API failures
- Add front-end error handling for chatbot network issues

## Testing
- `python -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_e_68adb0612f3c8328a964fa63088cdf42