### PR TITLE
feat: add live dashboard trackers

### DIFF
--- a/app.py
+++ b/app.py
@@ -416,6 +416,58 @@ def admin_dashboard():
     db.close()
     return render_template("admin/dashboard.html", stats=stats, monthly=monthly, bycat=bycat, bystatus=bystatus, companies=companies, avg_hours=avg_hours)
 
+
+@app.route("/admin/stats")
+@login_required
+@role_required("admin")
+def admin_stats_api():
+    db = get_db()
+    stats = db.execute(
+        """
+      SELECT
+        SUM(CASE WHEN status='new' THEN 1 ELSE 0 END) as new,
+        SUM(CASE WHEN status IN ('in_review','awaiting_info') THEN 1 ELSE 0 END) as inproc,
+        SUM(CASE WHEN status IN ('resolved','closed') THEN 1 ELSE 0 END) as closed
+      FROM reports
+    """
+    ).fetchone()
+    monthly = db.execute(
+        "SELECT substr(created_at,1,7) ym, COUNT(*) cnt FROM reports GROUP BY ym ORDER BY ym"
+    ).fetchall()
+    bycat = db.execute(
+        "SELECT category, COUNT(*) cnt FROM reports GROUP BY category ORDER BY cnt DESC"
+    ).fetchall()
+    bystatus = db.execute(
+        "SELECT status, COUNT(*) cnt FROM reports GROUP BY status"
+    ).fetchall()
+    rs = db.execute("SELECT id,created_at FROM reports").fetchall()
+    import datetime as dt
+    total = 0
+    n = 0
+    for r in rs:
+        m = db.execute(
+            "SELECT created_at FROM messages WHERE report_id=? AND sender IN ('admin','manager') ORDER BY id LIMIT 1",
+            (r["id"],),
+        ).fetchone()
+        if m:
+            t0 = dt.datetime.fromisoformat(r["created_at"])
+            t1 = dt.datetime.fromisoformat(m["created_at"])
+            total += (t1 - t0).total_seconds() / 3600
+            n += 1
+    avg_hours = round(total / n, 1) if n else 0
+    db.close()
+    return {
+        "stats": {
+            "new": stats["new"] or 0,
+            "inproc": stats["inproc"] or 0,
+            "closed": stats["closed"] or 0,
+            "avg_hours": avg_hours,
+        },
+        "monthly": [dict(r) for r in monthly],
+        "bycat": [dict(r) for r in bycat],
+        "bystatus": [dict(r) for r in bystatus],
+    }
+
 @app.route("/admin/companies", methods=["GET","POST"])
 @login_required
 @role_required("admin")
@@ -616,6 +668,44 @@ def manager_overview():
     bycat=db.execute("SELECT category, COUNT(*) cnt FROM reports WHERE company_id=? GROUP BY category ORDER BY cnt DESC",(cid,)).fetchall()
     db.close()
     return render_template("manager/overview.html", stats=stats, monthly=monthly, bycat=bycat)
+
+
+@app.route("/manager/stats")
+@login_required
+@role_required("manager")
+def manager_stats_api():
+    cid = session.get("company_id")
+    db = get_db()
+    stats = db.execute(
+        """
+      SELECT
+        SUM(CASE WHEN status='new' THEN 1 ELSE 0 END) AS new,
+        SUM(CASE WHEN status IN ('in_review','awaiting_info') THEN 1 ELSE 0 END) AS inproc,
+        SUM(CASE WHEN status IN ('resolved','closed') THEN 1 ELSE 0 END) AS closed,
+        COUNT(*) AS assigned
+      FROM reports
+      WHERE company_id=?
+    """,
+        (cid,),
+    ).fetchone()
+    monthly = db.execute(
+        "SELECT substr(created_at,1,7) ym, COUNT(*) cnt FROM reports WHERE company_id=? GROUP BY ym ORDER BY ym",
+        (cid,),
+    ).fetchall()
+    bycat = db.execute(
+        "SELECT category, COUNT(*) cnt FROM reports WHERE company_id=? GROUP BY category ORDER BY cnt DESC",
+        (cid,),
+    ).fetchall()
+    db.close()
+    return {
+        "stats": {
+            "assigned": stats["assigned"] or 0,
+            "new": stats["new"] or 0,
+            "closed": stats["closed"] or 0,
+        },
+        "monthly": [dict(r) for r in monthly],
+        "bycat": [dict(r) for r in bycat],
+    }
 
 @app.route("/manager/messages")
 @login_required

--- a/templates/admin/dashboard.html
+++ b/templates/admin/dashboard.html
@@ -1,10 +1,10 @@
 {% extends "admin/frame.html" %}{% block admin %}
 <h2 class="text-2xl font-extrabold mb-4">Overview</h2>
 <div class="grid md:grid-cols-4 gap-4">
-  <div class="bg-white rounded-xl p-4 border shadow-glass"><div class="text-base-muted">New</div><div class="text-3xl font-extrabold">{{ stats.new or 0 }}</div></div>
-  <div class="bg-white rounded-xl p-4 border shadow-glass"><div class="text-base-muted">In Process</div><div class="text-3xl font-extrabold">{{ stats.inproc or 0 }}</div></div>
-  <div class="bg-white rounded-xl p-4 border shadow-glass"><div class="text-base-muted">Closed</div><div class="text-3xl font-extrabold">{{ stats.closed or 0 }}</div></div>
-  <div class="bg-white rounded-xl p-4 border shadow-glass"><div class="text-base-muted">Avg. First Response</div><div class="text-3xl font-extrabold">{{ avg_hours }} h</div></div>
+  <div class="bg-white rounded-xl p-4 border shadow-glass"><div class="text-base-muted">New</div><div id="count-new" class="text-3xl font-extrabold">{{ stats.new or 0 }}</div></div>
+  <div class="bg-white rounded-xl p-4 border shadow-glass"><div class="text-base-muted">In Process</div><div id="count-inproc" class="text-3xl font-extrabold">{{ stats.inproc or 0 }}</div></div>
+  <div class="bg-white rounded-xl p-4 border shadow-glass"><div class="text-base-muted">Closed</div><div id="count-closed" class="text-3xl font-extrabold">{{ stats.closed or 0 }}</div></div>
+  <div class="bg-white rounded-xl p-4 border shadow-glass"><div class="text-base-muted">Avg. First Response</div><div id="avg-hours" class="text-3xl font-extrabold">{{ avg_hours }} h</div></div>
 </div>
 
 <div class="grid lg:grid-cols-3 gap-4 mt-6">
@@ -32,22 +32,43 @@
 
 <script>
 const colors = ["#3b82f6","#22c55e","#ec4899","#8b5cf6","#f59e0b","#06b6d4","#64748b","#ef4444"];
-new Chart(document.getElementById('byMonth'), {
+const chartMonth = new Chart(document.getElementById('byMonth'), {
   type:'line',
   data:{labels:{{ monthly|map(attribute='ym')|list|tojson }},
         datasets:[{label:'Reports',data:{{ monthly|map(attribute='cnt')|list|tojson }},
                    borderColor:colors[0]}]}
 });
-new Chart(document.getElementById('byCat'), {
+const chartCat = new Chart(document.getElementById('byCat'), {
   type:'bar',
   data:{labels:{{ bycat|map(attribute='category')|list|tojson }},
         datasets:[{label:'By Category',data:{{ bycat|map(attribute='cnt')|list|tojson }},
                    backgroundColor:colors}]}
 });
-new Chart(document.getElementById('byStatus'), {
+const chartStatus = new Chart(document.getElementById('byStatus'), {
   type:'doughnut',
   data:{labels:{{ bystatus|map(attribute='status')|list|tojson }},
         datasets:[{data:{{ bystatus|map(attribute='cnt')|list|tojson }},backgroundColor:colors}]}
 });
+
+async function refresh() {
+  const res = await fetch("{{ url_for('admin_stats_api') }}");
+  const data = await res.json();
+  document.getElementById('count-new').textContent = data.stats.new;
+  document.getElementById('count-inproc').textContent = data.stats.inproc;
+  document.getElementById('count-closed').textContent = data.stats.closed;
+  document.getElementById('avg-hours').textContent = data.stats.avg_hours + ' h';
+
+  chartMonth.data.labels = data.monthly.map(r => r.ym);
+  chartMonth.data.datasets[0].data = data.monthly.map(r => r.cnt);
+  chartCat.data.labels = data.bycat.map(r => r.category);
+  chartCat.data.datasets[0].data = data.bycat.map(r => r.cnt);
+  chartStatus.data.labels = data.bystatus.map(r => r.status);
+  chartStatus.data.datasets[0].data = data.bystatus.map(r => r.cnt);
+  chartMonth.update();
+  chartCat.update();
+  chartStatus.update();
+}
+setInterval(refresh, 10000);
+refresh();
 </script>
 {% endblock %}

--- a/templates/manager/overview.html
+++ b/templates/manager/overview.html
@@ -1,9 +1,9 @@
 {% extends "manager/frame.html" %}{% block manager %}
 <h2 class="text-2xl font-extrabold mb-4">Overview</h2>
 <div class="grid md:grid-cols-3 gap-4">
-  <div class="bg-white rounded-xl p-4 border shadow-glass"><div class="text-base-muted">Assigned</div><div class="text-3xl font-extrabold">{{ stats.assigned or 0 }}</div></div>
-  <div class="bg-white rounded-xl p-4 border shadow-glass"><div class="text-base-muted">New</div><div class="text-3xl font-extrabold">{{ stats.new or 0 }}</div></div>
-  <div class="bg-white rounded-xl p-4 border shadow-glass"><div class="text-base-muted">Closed</div><div class="text-3xl font-extrabold">{{ stats.closed or 0 }}</div></div>
+  <div class="bg-white rounded-xl p-4 border shadow-glass"><div class="text-base-muted">Assigned</div><div id="count-assigned" class="text-3xl font-extrabold">{{ stats.assigned or 0 }}</div></div>
+  <div class="bg-white rounded-xl p-4 border shadow-glass"><div class="text-base-muted">New</div><div id="count-new" class="text-3xl font-extrabold">{{ stats.new or 0 }}</div></div>
+  <div class="bg-white rounded-xl p-4 border shadow-glass"><div class="text-base-muted">Closed</div><div id="count-closed" class="text-3xl font-extrabold">{{ stats.closed or 0 }}</div></div>
 </div>
 <div class="grid lg:grid-cols-2 gap-4 mt-6">
   <div class="bg-white rounded-xl p-4 border shadow-glass"><canvas id="m"></canvas></div>
@@ -11,13 +11,30 @@
 </div>
 <script>
 const colors=["#3b82f6","#22c55e","#ec4899","#8b5cf6","#f59e0b","#06b6d4","#64748b","#ef4444"];
-new Chart(document.getElementById('m'), {
-  type:'line', data:{labels:{{ monthly|map(attribute='ym')|list|tojson }},
-  datasets:[{label:'Reports',data:{{ monthly|map(attribute='cnt')|list|tojson }}, borderColor:colors[1]}]}
+const chartM=new Chart(document.getElementById('m'),{
+  type:'line',data:{labels:{{ monthly|map(attribute='ym')|list|tojson }},
+  datasets:[{label:'Reports',data:{{ monthly|map(attribute='cnt')|list|tojson }},borderColor:colors[1]}]}
 });
-new Chart(document.getElementById('c'), {
-  type:'bar', data:{labels:{{ bycat|map(attribute='category')|list|tojson }},
-  datasets:[{label:'By Category',data:{{ bycat|map(attribute='cnt')|list|tojson }}, backgroundColor:colors}]}
+const chartC=new Chart(document.getElementById('c'),{
+  type:'bar',data:{labels:{{ bycat|map(attribute='category')|list|tojson }},
+  datasets:[{label:'By Category',data:{{ bycat|map(attribute='cnt')|list|tojson }},backgroundColor:colors}]}
 });
+
+async function refresh(){
+  const res=await fetch("{{ url_for('manager_stats_api') }}");
+  const data=await res.json();
+  document.getElementById('count-assigned').textContent=data.stats.assigned;
+  document.getElementById('count-new').textContent=data.stats.new;
+  document.getElementById('count-closed').textContent=data.stats.closed;
+
+  chartM.data.labels=data.monthly.map(r=>r.ym);
+  chartM.data.datasets[0].data=data.monthly.map(r=>r.cnt);
+  chartC.data.labels=data.bycat.map(r=>r.category);
+  chartC.data.datasets[0].data=data.bycat.map(r=>r.cnt);
+  chartM.update();
+  chartC.update();
+}
+setInterval(refresh,10000);
+refresh();
 </script>
 {% endblock %}


### PR DESCRIPTION
## Summary
- add JSON endpoints for admin and manager stats
- auto-refresh dashboards with live data and charts

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68adbe5f62308328a49b8c2255d2998a