### PR TITLE
Handle invalid JSON in chatbot endpoint

### DIFF
--- a/app.py
+++ b/app.py
@@ -918,7 +918,9 @@ def manager_notifications():
 # ----------------- AI chatbot
 @app.route("/chatbot", methods=["POST"])
 def chatbot():
-    data = request.get_json() or {}
+    data = request.get_json(silent=True) or {}
+    if not isinstance(data, dict):
+        data = {}
     message = (data.get("message") or "").strip()
     if not message:
         return {"reply": "Please say something."}

--- a/tests/test_chatbot.py
+++ b/tests/test_chatbot.py
@@ -17,6 +17,11 @@ def test_chatbot_empty_message():
     resp = client.post('/chatbot', json={})
     assert resp.get_json()['reply'] == 'Please say something.'
 
+
+def test_chatbot_handles_invalid_json():
+    resp = client.post('/chatbot', data='not json', content_type='application/json')
+    assert resp.get_json()['reply'] == 'Please say something.'
+
 def test_chatbot_history_and_no_key():
     resp = client.post('/chatbot', json={'message': 'Hello'})
     data = resp.get_json()


### PR DESCRIPTION
## Summary
- Gracefully handle invalid or non-dict JSON payloads in `/chatbot`
- Test chatbot endpoint with invalid JSON input

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68adc1862a0083288473eb3a3d344e1b