### PR TITLE
Allow manual assignment of reports to managers

### DIFF
--- a/app.py
+++ b/app.py
@@ -152,7 +152,9 @@ def init_db():
           done_so_far TEXT,
           wants_feedback TEXT,
           memorable TEXT,
-          FOREIGN KEY(company_id) REFERENCES companies(id) ON DELETE CASCADE
+          manager_id INTEGER,
+          FOREIGN KEY(company_id) REFERENCES companies(id) ON DELETE CASCADE,
+          FOREIGN KEY(manager_id) REFERENCES users(id) ON DELETE SET NULL
         );
         CREATE TABLE IF NOT EXISTS messages(
           id SERIAL PRIMARY KEY,
@@ -201,7 +203,9 @@ def init_db():
           done_so_far TEXT,
           wants_feedback TEXT,
           memorable TEXT,
-          FOREIGN KEY(company_id) REFERENCES companies(id) ON DELETE CASCADE
+          manager_id INTEGER,
+          FOREIGN KEY(company_id) REFERENCES companies(id) ON DELETE CASCADE,
+          FOREIGN KEY(manager_id) REFERENCES users(id) ON DELETE SET NULL
         );
         -- messages.channel: 'rep' (admin<->reporter), 'mgr' (admin<->manager)
         CREATE TABLE IF NOT EXISTS messages(
@@ -240,13 +244,48 @@ def init_db():
             cc = comps[i%len(comps)]
             token = secrets.token_urlsafe(10)
             pin   = str(random.randint(100000,999999))
-            cur = c.execute("""INSERT INTO reports(company_id,company_code,subject,content,category,status,reporter_contact,anon_token,anon_pin,created_at)
-                         VALUES (?,?,?,?,?,?,?,?,?,?) RETURNING id""",
-                         (cc["id"], cc["code"], f"Demo subject {i+1}", f"Demo content {i+1}", random.choice(CATEGORIES),
-                          random.choice(STATUSES), "", token, pin, now_iso()))
-            rid = cur.fetchone()["id"]
-            c.execute("INSERT INTO messages(report_id,channel,sender,body,created_at) VALUES (?,?,?,?,?)",
-                      (rid,"rep","reporter","Hello, I want to remain anonymous.", now_iso()))
+            if USE_POSTGRES:
+                cur = c.execute(
+                    """INSERT INTO reports(company_id,company_code,subject,content,category,status,reporter_contact,anon_token,anon_pin,created_at,manager_id)
+                         VALUES (?,?,?,?,?,?,?,?,?,?,?) RETURNING id""",
+                    (
+                        cc["id"],
+                        cc["code"],
+                        f"Demo subject {i+1}",
+                        f"Demo content {i+1}",
+                        random.choice(CATEGORIES),
+                        random.choice(STATUSES),
+                        "",
+                        token,
+                        pin,
+                        now_iso(),
+                        None,
+                    ),
+                )
+                rid = cur.fetchone()["id"]
+            else:
+                cur = c.execute(
+                    """INSERT INTO reports(company_id,company_code,subject,content,category,status,reporter_contact,anon_token,anon_pin,created_at,manager_id)
+                         VALUES (?,?,?,?,?,?,?,?,?,?,?)""",
+                    (
+                        cc["id"],
+                        cc["code"],
+                        f"Demo subject {i+1}",
+                        f"Demo content {i+1}",
+                        random.choice(CATEGORIES),
+                        random.choice(STATUSES),
+                        "",
+                        token,
+                        pin,
+                        now_iso(),
+                        None,
+                    ),
+                )
+                rid = cur.lastrowid
+            c.execute(
+                "INSERT INTO messages(report_id,channel,sender,body,created_at) VALUES (?,?,?,?,?)",
+                (rid, "rep", "reporter", "Hello, I want to remain anonymous.", now_iso()),
+            )
     # settings placeholders
     defaults = {
       "smtp_url":"",
@@ -441,10 +480,50 @@ def report():
             return render_template("report.html", captcha_a=a, captcha_b=b)
 
         token=secrets.token_urlsafe(12); pin=f"{secrets.randbelow(900000)+100000}"
-        cur=db.execute("""INSERT INTO reports(company_id,company_code,subject,content,category,status,reporter_contact,anon_token,anon_pin,created_at,done_so_far,wants_feedback,memorable)
-                      VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?) RETURNING id""",
-                   (comp["id"], comp["code"], subject, content, category, "new", contact, token, pin, now_iso(), done_so_far, wants_feedback, memorable))
-        rid=cur.fetchone()["id"]
+        if USE_POSTGRES:
+            cur=db.execute(
+                """INSERT INTO reports(company_id,company_code,subject,content,category,status,reporter_contact,anon_token,anon_pin,created_at,done_so_far,wants_feedback,memorable,manager_id)
+                      VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?) RETURNING id""",
+                (
+                    comp["id"],
+                    comp["code"],
+                    subject,
+                    content,
+                    category,
+                    "new",
+                    contact,
+                    token,
+                    pin,
+                    now_iso(),
+                    done_so_far,
+                    wants_feedback,
+                    memorable,
+                    None,
+                ),
+            )
+            rid=cur.fetchone()["id"]
+        else:
+            cur=db.execute(
+                """INSERT INTO reports(company_id,company_code,subject,content,category,status,reporter_contact,anon_token,anon_pin,created_at,done_so_far,wants_feedback,memorable,manager_id)
+                      VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?)""",
+                (
+                    comp["id"],
+                    comp["code"],
+                    subject,
+                    content,
+                    category,
+                    "new",
+                    contact,
+                    token,
+                    pin,
+                    now_iso(),
+                    done_so_far,
+                    wants_feedback,
+                    memorable,
+                    None,
+                ),
+            )
+            rid=cur.lastrowid
         db.execute("INSERT INTO messages(report_id,channel,sender,body,created_at) VALUES (?,?,?,?,?)",
                    (rid,"rep","reporter","Report submitted.", now_iso()))
         db.commit(); db.close()
@@ -670,7 +749,7 @@ def admin_reports():
     status=(request.args.get("status") or "")
     category=(request.args.get("category") or "")
     code=(request.args.get("company_code") or "").strip().upper()
-    args=[]; sql="SELECT id,company_code,category,status,created_at FROM reports WHERE 1=1"
+    args=[]; sql="SELECT r.id,r.company_code,r.category,r.status,r.created_at,u.email AS manager_email FROM reports r LEFT JOIN users u ON u.id=r.manager_id WHERE 1=1"
     if q: sql+=" AND (subject LIKE ? OR content LIKE ?)"; args += [f"%{q}%",f"%{q}%"]
     if status: sql+=" AND status=?"; args.append(status)
     if category: sql+=" AND category=?"; args.append(category)
@@ -699,11 +778,17 @@ def admin_report_detail(rid):
         elif act=="msg_mgr":
             body=(request.form.get("body") or "").strip()
             if body: db.execute("INSERT INTO messages(report_id,channel,sender,body,created_at) VALUES (?,?,?,?,?)", (rid,"mgr","admin",body,now_iso()))
+        elif act=="assign_mgr":
+            mid=request.form.get("manager_id") or ""
+            try: mid=int(mid) if mid else None
+            except: mid=None
+            db.execute("UPDATE reports SET manager_id=? WHERE id=?", (mid, rid))
         db.commit()
+    managers=db.execute("SELECT id,email FROM users WHERE role='manager' AND company_id=?", (r["company_id"],)).fetchall()
     msgs_rep=db.execute("SELECT created_at,sender,body FROM messages WHERE report_id=? AND channel='rep' ORDER BY id",(rid,)).fetchall()
     msgs_mgr=db.execute("SELECT created_at,sender,body FROM messages WHERE report_id=? AND channel='mgr' ORDER BY id",(rid,)).fetchall()
     db.close()
-    return render_template("admin/report_detail.html", r=r, msgs_rep=msgs_rep, msgs_mgr=msgs_mgr, statuses=STATUSES)
+    return render_template("admin/report_detail.html", r=r, msgs_rep=msgs_rep, msgs_mgr=msgs_mgr, statuses=STATUSES, managers=managers)
 
 @app.route("/admin/users", methods=["GET","POST"])
 @login_required
@@ -813,7 +898,7 @@ def admin_notifications():
 @login_required
 @role_required("manager")
 def manager_overview():
-    cid=session.get("company_id")
+    mid=session.get("user_id")
     db=get_db()
     stats=db.execute(
         """
@@ -823,12 +908,12 @@ def manager_overview():
         SUM(CASE WHEN status IN ('resolved','closed') THEN 1 ELSE 0 END) AS closed,
         COUNT(*) AS assigned
       FROM reports
-      WHERE company_id=?
+      WHERE manager_id=?
     """,
-        (cid,),
+        (mid,),
     ).fetchone()
-    monthly=db.execute("SELECT substr(created_at,1,7) ym, COUNT(*) cnt FROM reports WHERE company_id=? GROUP BY ym ORDER BY ym",(cid,)).fetchall()
-    bycat=db.execute("SELECT category, COUNT(*) cnt FROM reports WHERE company_id=? GROUP BY category ORDER BY cnt DESC",(cid,)).fetchall()
+    monthly=db.execute("SELECT substr(created_at,1,7) ym, COUNT(*) cnt FROM reports WHERE manager_id=? GROUP BY ym ORDER BY ym",(mid,)).fetchall()
+    bycat=db.execute("SELECT category, COUNT(*) cnt FROM reports WHERE manager_id=? GROUP BY category ORDER BY cnt DESC",(mid,)).fetchall()
     db.close()
     return render_template("manager/overview.html", stats=stats, monthly=monthly, bycat=bycat)
 
@@ -837,7 +922,7 @@ def manager_overview():
 @login_required
 @role_required("manager")
 def manager_stats_api():
-    cid = session.get("company_id")
+    mid = session.get("user_id")
     db = get_db()
     stats = db.execute(
         """
@@ -847,17 +932,17 @@ def manager_stats_api():
         SUM(CASE WHEN status IN ('resolved','closed') THEN 1 ELSE 0 END) AS closed,
         COUNT(*) AS assigned
       FROM reports
-      WHERE company_id=?
+      WHERE manager_id=?
     """,
-        (cid,),
+        (mid,),
     ).fetchone()
     monthly = db.execute(
-        "SELECT substr(created_at,1,7) ym, COUNT(*) cnt FROM reports WHERE company_id=? GROUP BY ym ORDER BY ym",
-        (cid,),
+        "SELECT substr(created_at,1,7) ym, COUNT(*) cnt FROM reports WHERE manager_id=? GROUP BY ym ORDER BY ym",
+        (mid,),
     ).fetchall()
     bycat = db.execute(
-        "SELECT category, COUNT(*) cnt FROM reports WHERE company_id=? GROUP BY category ORDER BY cnt DESC",
-        (cid,),
+        "SELECT category, COUNT(*) cnt FROM reports WHERE manager_id=? GROUP BY category ORDER BY cnt DESC",
+        (mid,),
     ).fetchall()
     db.close()
     return {
@@ -874,10 +959,10 @@ def manager_stats_api():
 @login_required
 @role_required("manager")
 def manager_messages():
-    cid=session.get("company_id"); db=get_db()
+    mid=session.get("user_id"); db=get_db()
     rows=db.execute("""SELECT r.id, r.company_code, MAX(m.created_at) AS updated
                        FROM reports r LEFT JOIN messages m ON m.report_id=r.id AND m.channel='mgr'
-                       WHERE r.company_id=? GROUP BY r.id ORDER BY r.id DESC""",(cid,)).fetchall()
+                       WHERE r.manager_id=? GROUP BY r.id ORDER BY r.id DESC""",(mid,)).fetchall()
     db.close()
     return render_template("manager/messages.html", reports=rows)
 
@@ -885,10 +970,10 @@ def manager_messages():
 @login_required
 @role_required("manager")
 def manager_messages_thread(rid):
-    cid=session.get("company_id")
+    mid=session.get("user_id")
     db=get_db()
-    r=db.execute("SELECT id,company_id,company_code FROM reports WHERE id=?", (rid,)).fetchone()
-    if not r or r["company_id"]!=cid: db.close(); abort(403)
+    r=db.execute("SELECT id,manager_id,company_code FROM reports WHERE id=?", (rid,)).fetchone()
+    if not r or r["manager_id"]!=mid: db.close(); abort(403)
     if request.method=="POST":
         body=(request.form.get("body") or "").strip()
         if body: db.execute("INSERT INTO messages(report_id,channel,sender,body,created_at) VALUES (?,?,?,?,?)",(rid,"mgr","manager",body,now_iso())); db.commit()
@@ -901,16 +986,16 @@ def manager_messages_thread(rid):
 @role_required("manager")
 def manager_notifications():
     notes=[]
-    cid=session.get("company_id"); db=get_db()
+    mid=session.get("user_id"); db=get_db()
     if USE_POSTGRES:
         sql="""SELECT COUNT(*) c FROM messages m JOIN reports r ON r.id=m.report_id
-                 WHERE r.company_id=? AND m.channel='mgr' AND m.sender='admin'
+                 WHERE r.manager_id=? AND m.channel='mgr' AND m.sender='admin'
                  AND m.created_at::timestamp > NOW() - INTERVAL '7 days'"""
     else:
         sql="""SELECT COUNT(*) c FROM messages m JOIN reports r ON r.id=m.report_id
-                 WHERE r.company_id=? AND m.channel='mgr' AND m.sender='admin'
+                 WHERE r.manager_id=? AND m.channel='mgr' AND m.sender='admin'
                  AND datetime(m.created_at) > datetime('now','-7 day')"""
-    cnt=db.execute(sql,(cid,)).fetchone()["c"]
+    cnt=db.execute(sql,(mid,)).fetchone()["c"]
     if cnt: notes.append(f"{cnt} new admin message(s) in last 7 days.")
     db.close()
     return render_template("manager/notifications.html", notes=notes)

--- a/templates/admin/report_detail.html
+++ b/templates/admin/report_detail.html
@@ -13,6 +13,15 @@
       </select>
       <button class="ml-2 px-3 py-2 rounded-lg bg-neutral-800 text-white">Update</button>
     </form>
+    <form method="post" class="mt-4">
+      <input type="hidden" name="action" value="assign_mgr">
+      <label class="block text-sm mb-1">Assign to manager</label>
+      <select name="manager_id" class="rounded-lg border px-3 py-2">
+        <option value="">Unassigned</option>
+        {% for m in managers %}<option value="{{ m.id }}" {% if r.manager_id==m.id %}selected{% endif %}>{{ m.email }}</option>{% endfor %}
+      </select>
+      <button class="ml-2 px-3 py-2 rounded-lg bg-neutral-800 text-white">Assign</button>
+    </form>
   </div>
   <div class="bg-white rounded-xl p-4 border shadow-glass">
     <div class="grid md:grid-cols-2 gap-4">

--- a/templates/admin/reports.html
+++ b/templates/admin/reports.html
@@ -15,13 +15,14 @@
 </form>
 <div class="bg-white rounded-xl p-4 border shadow-glass">
   <table class="w-full text-sm">
-    <tr class="text-left border-b"><th class="py-2">ID</th><th>Company</th><th>Category</th><th>Status</th><th>Created</th><th></th></tr>
+    <tr class="text-left border-b"><th class="py-2">ID</th><th>Company</th><th>Category</th><th>Status</th><th>Manager</th><th>Created</th><th></th></tr>
     {% for r in rows %}
       <tr class="border-b">
         <td class="py-2">{{ r.id }}</td>
         <td><code>{{ r.company_code }}</code></td>
         <td>{{ r.category }}</td>
         <td>{{ r.status }}</td>
+        <td>{{ r.manager_email or '—' }}</td>
         <td>{{ r.created_at[:19] }}</td>
         <td><a class="text-neon-blue" href="{{ url_for('admin_report_detail', rid=r.id) }}">Open</a></td>
       </tr>

--- a/tests/test_report_assignment.py
+++ b/tests/test_report_assignment.py
@@ -1,0 +1,26 @@
+import os, sys, importlib
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+if os.path.exists('carewhistle.db'):
+    os.remove('carewhistle.db')
+
+import app
+importlib.reload(app)
+
+admin_client = app.app.test_client()
+manager_client = app.app.test_client()
+
+def login(client, email, password):
+    return client.post('/login', data={'email': email, 'password': password}, follow_redirects=True)
+
+def test_manager_sees_assigned_report():
+    login(admin_client, 'admin@admin.com', 'password')
+    db = app.get_db()
+    rid = db.execute('SELECT id FROM reports ORDER BY id LIMIT 1').fetchone()['id']
+    mid = db.execute("SELECT id FROM users WHERE role='manager' ORDER BY id LIMIT 1").fetchone()['id']
+    db.close()
+    admin_client.post(f'/admin/report/{rid}', data={'action': 'assign_mgr', 'manager_id': mid}, follow_redirects=True)
+    login(manager_client, 'manager@brightcare.com', 'manager1')
+    resp = manager_client.get('/manager/messages')
+    assert str(rid).encode() in resp.data


### PR DESCRIPTION
## Summary
- add `manager_id` to reports and provide admin UI for assigning managers
- show manager assignments in admin report list
- restrict manager dashboards and messages to assigned reports
- avoid SQLite `RETURNING` conflicts by using `lastrowid` when inserting reports

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68adc5636e2c8328b56179b13fbf2cc6