### PR TITLE
Polish UI with refined white and blue palette

### DIFF
--- a/templates/admin/companies.html
+++ b/templates/admin/companies.html
@@ -3,7 +3,7 @@
 <form method="post" class="bg-white rounded-xl p-4 border shadow-glass grid md:grid-cols-3 gap-4 mb-4">
   <div><label class="block text-sm mb-1">Name</label><input name="name" class="w-full rounded-lg border px-3 py-2" required></div>
   <div><label class="block text-sm mb-1">Company Code (auto or custom)</label><input name="code" class="w-full rounded-lg border px-3 py-2" placeholder="Leave blank for auto"></div>
-  <div class="flex items-end"><button class="px-4 py-2 rounded-lg bg-neon-blue text-white">Add Company</button></div>
+  <div class="flex items-end"><button class="px-4 py-2 rounded-lg bg-brand-blue text-white hover:bg-brand-indigo transition-colors">Add Company</button></div>
 </form>
 <div class="bg-white rounded-xl p-4 border shadow-glass">
   <table class="w-full text-sm">
@@ -14,7 +14,7 @@
         <td><code>{{ c.code }}</code></td>
         <td>{{ c.created_at[:10] }}</td>
         <td>
-          <a class="text-neon-blue mr-3" href="{{ url_for('admin_company', company_id=c.id) }}">Open</a>
+          <a class="text-brand-blue hover:text-brand-indigo transition-colors mr-3" href="{{ url_for('admin_company', company_id=c.id) }}">Open</a>
           <form method="post" action="{{ url_for('admin_company_delete', company_id=c.id) }}" style="display:inline" onsubmit="return confirm('Delete company and its reports?')">
             <button class="text-red-600">Delete</button>
           </form>

--- a/templates/admin/company_dashboard.html
+++ b/templates/admin/company_dashboard.html
@@ -16,14 +16,14 @@
       {% for r in recent %}
       <tr class="border-b">
         <td class="py-2">{{ r.id }}</td><td>{{ r.status }}</td><td>{{ r.created_at[:10] }}</td>
-        <td><a class="text-neon-blue" href="{{ url_for('admin_report_detail', rid=r.id) }}">Open</a></td>
+        <td><a class="text-brand-blue hover:text-brand-indigo transition-colors" href="{{ url_for('admin_report_detail', rid=r.id) }}">Open</a></td>
       </tr>
       {% endfor %}
     </table>
   </div>
 </div>
 <script>
-const colors=["#3b82f6","#22c55e","#ec4899","#8b5cf6","#f59e0b","#06b6d4","#64748b","#ef4444"];
+const colors=["#1e40af","#3b82f6","#0ea5e9","#f472b6","#fbbf24","#94a3b8","#64748b","#ef4444"];
 new Chart(document.getElementById('m'), {
   type:'line',
   data:{labels:{{ monthly|map(attribute='ym')|list|tojson }},

--- a/templates/admin/dashboard.html
+++ b/templates/admin/dashboard.html
@@ -24,14 +24,14 @@
         <td>{{ c.newc or 0 }}</td>
         <td>{{ c.inpc or 0 }}</td>
         <td>{{ c.clos or 0 }}</td>
-        <td><a class="text-neon-blue" href="{{ url_for('admin_company', company_id=c.id) }}">View</a></td>
+        <td><a class="text-brand-blue hover:text-brand-indigo transition-colors" href="{{ url_for('admin_company', company_id=c.id) }}">View</a></td>
       </tr>
     {% endfor %}
   </table>
 </div>
 
 <script>
-const colors = ["#3b82f6","#22c55e","#ec4899","#8b5cf6","#f59e0b","#06b6d4","#64748b","#ef4444"];
+const colors = ["#1e40af","#3b82f6","#0ea5e9","#f472b6","#fbbf24","#94a3b8","#64748b","#ef4444"];
 new Chart(document.getElementById('byMonth'), {
   type:'line',
   data:{labels:{{ monthly|map(attribute='ym')|list|tojson }},

--- a/templates/admin/media.html
+++ b/templates/admin/media.html
@@ -2,7 +2,7 @@
 <h2 class="text-2xl font-extrabold mb-4">Media</h2>
 <form method="post" enctype="multipart/form-data" class="bg-white rounded-xl p-4 border shadow-glass flex items-end gap-3 mb-4">
   <div><label class="block text-sm mb-1">Upload file</label><input type="file" name="file" class="block"></div>
-  <button class="px-4 py-2 rounded-lg bg-neutral-800 text-white">Upload</button>
+  <button class="px-4 py-2 rounded-lg bg-brand-blue text-white hover:bg-brand-indigo transition-colors">Upload</button>
 </form>
 <div class="grid md:grid-cols-3 gap-4">
   {% for f in files %}
@@ -10,7 +10,7 @@
     <div class="text-sm break-all">{{ f }}</div>
     <div class="text-xs text-base-muted mb-2">/media/{{ f }}</div>
     <div class="flex gap-2">
-      <a class="px-3 py-1 rounded bg-neutral-200" href="{{ url_for('media_file', filename=f) }}" target="_blank">Open</a>
+      <a class="px-3 py-1 rounded border border-brand-blue text-brand-blue hover:bg-brand-blue hover:text-white transition-colors" href="{{ url_for('media_file', filename=f) }}" target="_blank">Open</a>
       <form method="post" action="{{ url_for('admin_media_delete', fname=f) }}" onsubmit="return confirm('Delete file?')">
         <button class="px-3 py-1 rounded bg-red-600 text-white">Delete</button>
       </form>

--- a/templates/admin/report_detail.html
+++ b/templates/admin/report_detail.html
@@ -11,7 +11,7 @@
       <select name="status" class="rounded-lg border px-3 py-2">
         {% for s in statuses %}<option value="{{ s }}" {% if s==r.status %}selected{% endif %}>{{ s }}</option>{% endfor %}
       </select>
-      <button class="ml-2 px-3 py-2 rounded-lg bg-neutral-800 text-white">Update</button>
+      <button class="ml-2 px-3 py-2 rounded-lg bg-brand-indigo text-white hover:bg-brand-blue transition-colors">Update</button>
     </form>
   </div>
   <div class="bg-white rounded-xl p-4 border shadow-glass">
@@ -24,7 +24,7 @@
         <form method="post" class="mt-2">
           <input type="hidden" name="action" value="msg_rep">
           <textarea name="body" rows="2" class="w-full rounded-lg border px-3 py-2" required></textarea>
-          <button class="mt-2 px-3 py-2 rounded-lg bg-neon-blue text-white">Send</button>
+          <button class="mt-2 px-3 py-2 rounded-lg bg-brand-blue text-white hover:bg-brand-indigo transition-colors">Send</button>
         </form>
       </div>
       <div>
@@ -35,7 +35,7 @@
         <form method="post" class="mt-2">
           <input type="hidden" name="action" value="msg_mgr">
           <textarea name="body" rows="2" class="w-full rounded-lg border px-3 py-2" required></textarea>
-          <button class="mt-2 px-3 py-2 rounded-lg bg-neon-purple text-white">Send</button>
+          <button class="mt-2 px-3 py-2 rounded-lg bg-brand-indigo text-white hover:bg-brand-blue transition-colors">Send</button>
         </form>
       </div>
     </div>

--- a/templates/admin/reports.html
+++ b/templates/admin/reports.html
@@ -11,7 +11,7 @@
     <option value="">Any category</option>
     {% for c in categories %}<option {% if c==category %}selected{% endif %}>{{ c }}</option>{% endfor %}
   </select>
-  <button class="px-4 py-2 rounded-lg bg-neutral-800 text-white">Filter</button>
+  <button class="px-4 py-2 rounded-lg bg-brand-blue text-white hover:bg-brand-indigo transition-colors">Filter</button>
 </form>
 <div class="bg-white rounded-xl p-4 border shadow-glass">
   <table class="w-full text-sm">
@@ -23,7 +23,7 @@
         <td>{{ r.category }}</td>
         <td>{{ r.status }}</td>
         <td>{{ r.created_at[:19] }}</td>
-        <td><a class="text-neon-blue" href="{{ url_for('admin_report_detail', rid=r.id) }}">Open</a></td>
+        <td><a class="text-brand-blue hover:text-brand-indigo transition-colors" href="{{ url_for('admin_report_detail', rid=r.id) }}">Open</a></td>
       </tr>
     {% endfor %}
   </table>

--- a/templates/admin/settings.html
+++ b/templates/admin/settings.html
@@ -8,6 +8,6 @@
   <div><label class="block text-sm mb-1">Mongo URL</label><input name="mongo_url" value="{{ settings.mongo_url or '' }}" class="w-full rounded-lg border px-3 py-2"></div>
   <div><label class="block text-sm mb-1">OpenAI Key</label><input name="openai_key" value="{{ settings.openai_key or '' }}" class="w-full rounded-lg border px-3 py-2"></div>
   <div class="md:col-span-2"><label class="block text-sm mb-1">YouTube URL (homepage video)</label><input name="youtube_url" value="{{ settings.youtube_url or '' }}" class="w-full rounded-lg border px-3 py-2"></div>
-  <div class="md:col-span-2"><button class="px-4 py-2 rounded-lg bg-neon-blue text-white">Save</button></div>
+  <div class="md:col-span-2"><button class="px-4 py-2 rounded-lg bg-brand-blue text-white hover:bg-brand-indigo transition-colors">Save</button></div>
 </form>
 {% endblock %}

--- a/templates/admin/users.html
+++ b/templates/admin/users.html
@@ -9,7 +9,7 @@
       {% for c in companies %}<option value="{{ c.id }}">{{ c.name }} ({{ c.code }})</option>{% endfor %}
     </select>
   </div>
-  <div class="md:col-span-3"><button class="px-4 py-2 rounded-lg bg-neon-blue text-white">Create Manager</button></div>
+  <div class="md:col-span-3"><button class="px-4 py-2 rounded-lg bg-brand-blue text-white hover:bg-brand-indigo transition-colors">Create Manager</button></div>
 </form>
 
 <div class="bg-white rounded-xl p-4 border shadow-glass">

--- a/templates/chatbot.html
+++ b/templates/chatbot.html
@@ -2,10 +2,10 @@
   <div id="chatbot-log" class="p-2 flex-1 overflow-y-auto text-sm"></div>
   <form id="chatbot-form" class="flex border-t">
     <input id="chatbot-input" class="flex-1 p-2 text-sm" placeholder="Ask a question..." />
-    <button class="px-3 text-white bg-neon-blue">Send</button>
+    <button class="px-3 text-white bg-brand-blue hover:bg-brand-indigo transition-colors">Send</button>
   </form>
 </div>
-<button id="chatbot-toggle" class="fixed bottom-4 right-4 w-12 h-12 rounded-full bg-neon-blue text-white shadow-lg">💬</button>
+<button id="chatbot-toggle" class="fixed bottom-4 right-4 w-12 h-12 rounded-full bg-brand-blue text-white shadow-lg hover:bg-brand-indigo transition-colors">💬</button>
 <script>
   const toggle=document.getElementById('chatbot-toggle');
   const box=document.getElementById('chatbot-box');
@@ -26,7 +26,7 @@
         body:JSON.stringify({message:msg})
       });
       const data=await r.json();
-      log.innerHTML+=`<div class="text-left mb-1 text-neon-blue">${data.reply}</div>`;
+      log.innerHTML+=`<div class="text-left mb-1 text-brand-blue">${data.reply}</div>`;
     } catch(err){
       log.innerHTML+=`<div class="text-left mb-1 text-red-600">Error: ${err}</div>`;
     }

--- a/templates/follow.html
+++ b/templates/follow.html
@@ -10,7 +10,7 @@
       <label class="block text-sm mb-1">PIN</label>
       <input name="pin" required class="w-full rounded-lg border px-3 py-2">
     </div>
-    <button class="px-4 py-2 rounded-lg bg-neon-blue text-white">Open</button>
+    <button class="px-4 py-2 rounded-lg bg-brand-blue text-white hover:bg-brand-indigo transition-colors">Open</button>
   </form>
 </section>
 {% endblock %}

--- a/templates/follow_thread.html
+++ b/templates/follow_thread.html
@@ -14,7 +14,7 @@
     <form method="post" action="{{ url_for('follow_message', token=r.anon_token) }}" class="mt-4 grid gap-2">
       <label class="text-sm">Send a message to the investigator</label>
       <textarea name="body" rows="3" required class="rounded-lg border px-3 py-2"></textarea>
-      <button class="px-4 py-2 rounded-lg bg-neutral-800 text-white">Send</button>
+      <button class="px-4 py-2 rounded-lg bg-brand-blue text-white hover:bg-brand-indigo transition-colors">Send</button>
     </form>
   </div>
 </section>

--- a/templates/index.html
+++ b/templates/index.html
@@ -5,8 +5,8 @@
       <h1 class="text-4xl font-extrabold mb-3">One of the most securest Whistleblowing systems in the UK.</h1>
       <p class="text-base-muted mb-6">Modern, secure and anonymous — protect your company, your staff and your service users. If you already have a solution, check our price promise.</p>
       <div class="flex gap-3">
-        <a class="px-4 py-2 rounded-lg bg-neon-green text-white" href="{{ url_for('report') }}">Make a Report</a>
-        <a class="px-4 py-2 rounded-lg bg-neutral-200" href="{{ url_for('how') }}">How it works</a>
+        <a class="px-4 py-2 rounded-lg bg-brand-blue text-white hover:bg-brand-indigo transition-colors" href="{{ url_for('report') }}">Make a Report</a>
+        <a class="px-4 py-2 rounded-lg border border-brand-blue text-brand-blue hover:bg-brand-blue hover:text-white transition-colors" href="{{ url_for('how') }}">How it works</a>
       </div>
     </div>
     <div class="bg-white rounded-2xl p-6 border shadow-glass">

--- a/templates/layout.html
+++ b/templates/layout.html
@@ -10,8 +10,15 @@
       theme:{
         extend:{
           colors:{
-            base: { bg:"#f7f8fb", card:"#ffffff", ink:"#111827", muted:"#6b7280" },
-            neon: { blue:"#3b82f6", green:"#22c55e", pink:"#ec4899", purple:"#8b5cf6", amber:"#f59e0b", cyan:"#06b6d4" }
+            base: { bg:"#ffffff", card:"#f8fafc", ink:"#1e293b", muted:"#64748b" },
+            brand: {
+              blue:"#1e40af",
+              indigo:"#3b82f6",
+              cyan:"#0ea5e9",
+              pink:"#f472b6",
+              amber:"#fbbf24",
+              slate:"#94a3b8"
+            }
           },
           boxShadow:{
             glass:"0 10px 30px rgba(31,41,55,.08), inset 0 1px 0 rgba(255,255,255,.5)"
@@ -27,30 +34,30 @@
   <header class="sticky top-0 z-40 backdrop-blur bg-white/80 border-b">
     <div class="max-w-7xl mx-auto px-4 py-3 flex items-center gap-4">
       <a href="{{ url_for('home') }}" class="flex items-center gap-2 font-extrabold text-lg">
-        <span class="inline-flex items-center justify-center w-10 h-10 rounded-lg bg-gradient-to-br from-neon-blue to-neon-purple text-white shadow-glass ring-2 ring-white">
+        <span class="inline-flex items-center justify-center w-10 h-10 rounded-lg bg-gradient-to-br from-brand-blue to-brand-indigo text-white shadow-glass ring-2 ring-white">
           <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" class="w-5 h-5" fill="currentColor">
             <path d="M8.5 9A6.5 6.5 0 0 0 2 15.5 6.5 6.5 0 0 0 8.5 22 6.5 6.5 0 0 0 15 15.5V13.91L22 12V9H11V11H9V9H8.5M11 2V7H9V2H11M6.35 7.28c-.67.16-1.31.4-1.92.72L2.14 4.88 3.76 3.7 6.35 7.28M17.86 4.88 16.32 7h-2.47L16.24 3.7l1.62 1.18Z"/>
           </svg>
         </span>
-        <span class="bg-gradient-to-r from-neon-blue to-neon-purple bg-clip-text text-transparent">CareWhistle</span>
+        <span class="bg-gradient-to-r from-brand-blue to-brand-indigo bg-clip-text text-transparent">CareWhistle</span>
       </a>
       <nav class="ml-6 flex items-center gap-4 text-sm">
-        <a class="hover:text-neon-blue" href="{{ url_for('home') }}">Home</a>
-        <a class="hover:text-neon-blue" href="{{ url_for('how') }}">How it works</a>
-        <a class="hover:text-neon-blue" href="{{ url_for('report') }}">Make a Report</a>
-        <a class="hover:text-neon-blue" href="{{ url_for('pricing') }}">Plans & Pricing</a>
+        <a class="transition-colors hover:text-brand-blue" href="{{ url_for('home') }}">Home</a>
+        <a class="transition-colors hover:text-brand-blue" href="{{ url_for('how') }}">How it works</a>
+        <a class="transition-colors hover:text-brand-blue" href="{{ url_for('report') }}">Make a Report</a>
+        <a class="transition-colors hover:text-brand-blue" href="{{ url_for('pricing') }}">Plans & Pricing</a>
       </nav>
       <div class="ml-auto flex items-center gap-2">
-        <a class="px-3 py-1.5 rounded-lg bg-neutral-100 hover:bg-neutral-200" href="{{ url_for('follow') }}">Case Portal</a>
+        <a class="px-3 py-1.5 rounded-lg border border-brand-blue text-brand-blue hover:bg-brand-blue hover:text-white transition-colors" href="{{ url_for('follow') }}">Case Portal</a>
         {% if session.get('user_id') %}
           {% if session.get('role')=='admin' %}
-            <a class="px-3 py-1.5 rounded-lg bg-neon-blue text-white" href="{{ url_for('admin_dashboard') }}">Admin</a>
+            <a class="px-3 py-1.5 rounded-lg bg-brand-blue text-white" href="{{ url_for('admin_dashboard') }}">Admin</a>
           {% elif session.get('role')=='manager' %}
-            <a class="px-3 py-1.5 rounded-lg bg-neon-purple text-white" href="{{ url_for('manager_overview') }}">Manager</a>
+            <a class="px-3 py-1.5 rounded-lg bg-brand-indigo text-white" href="{{ url_for('manager_overview') }}">Manager</a>
           {% endif %}
-          <a class="px-3 py-1.5 rounded-lg bg-neutral-800 text-white" href="{{ url_for('logout') }}">Logout</a>
+          <a class="px-3 py-1.5 rounded-lg bg-brand-indigo text-white" href="{{ url_for('logout') }}">Logout</a>
         {% else %}
-          <a class="px-3 py-1.5 rounded-lg bg-neutral-800 text-white" href="{{ url_for('login') }}">Login</a>
+          <a class="px-3 py-1.5 rounded-lg bg-brand-blue text-white" href="{{ url_for('login') }}">Login</a>
         {% endif %}
       </div>
     </div>

--- a/templates/login.html
+++ b/templates/login.html
@@ -4,7 +4,7 @@
   <form method="post" class="bg-white rounded-xl p-6 border shadow-glass grid gap-4">
     <div><label class="block text-sm mb-1">Email</label><input name="email" required class="w-full rounded-lg border px-3 py-2" value="{{ request.form.email or '' }}"></div>
     <div><label class="block text-sm mb-1">Password</label><input name="password" type="password" required class="w-full rounded-lg border px-3 py-2"></div>
-    <button class="px-4 py-2 rounded-lg bg-neutral-800 text-white">Login</button>
+    <button class="px-4 py-2 rounded-lg bg-brand-blue text-white hover:bg-brand-indigo transition-colors">Login</button>
   </form>
 </section>
 {% endblock %}

--- a/templates/manager/messages.html
+++ b/templates/manager/messages.html
@@ -6,7 +6,7 @@
     {% for r in reports %}
       <tr class="border-b">
         <td class="py-2">{{ r.id }}</td><td><code>{{ r.company_code }}</code></td><td>{{ r.updated }}</td>
-        <td><a class="text-neon-blue" href="{{ url_for('manager_messages_thread', rid=r.id) }}">Open</a></td>
+        <td><a class="text-brand-blue hover:text-brand-indigo transition-colors" href="{{ url_for('manager_messages_thread', rid=r.id) }}">Open</a></td>
       </tr>
     {% endfor %}
   </table>

--- a/templates/manager/messages_thread.html
+++ b/templates/manager/messages_thread.html
@@ -9,7 +9,7 @@
   </div>
   <form method="post" class="mt-3 grid gap-2">
     <textarea name="body" rows="3" required class="rounded-lg border px-3 py-2"></textarea>
-    <button class="px-4 py-2 rounded-lg bg-neon-purple text-white">Send</button>
+    <button class="px-4 py-2 rounded-lg bg-brand-indigo text-white hover:bg-brand-blue transition-colors">Send</button>
   </form>
 </div>
 {% endblock %}

--- a/templates/pricing.html
+++ b/templates/pricing.html
@@ -9,10 +9,10 @@
     </ul>
     <div class="mt-6 flex gap-2">
       <form action="{{ url_for('checkout_stripe') }}" method="post">
-        <button class="px-4 py-2 rounded bg-neon-blue text-white">Pay with Stripe</button>
+        <button class="px-4 py-2 rounded bg-brand-blue text-white hover:bg-brand-indigo transition-colors">Pay with Stripe</button>
       </form>
       <form action="{{ url_for('checkout_paypal') }}" method="post">
-        <button class="px-4 py-2 rounded bg-neutral-800 text-white">Pay with PayPal</button>
+        <button class="px-4 py-2 rounded bg-brand-indigo text-white hover:bg-brand-blue transition-colors">Pay with PayPal</button>
       </form>
     </div>
   </div>

--- a/templates/report.html
+++ b/templates/report.html
@@ -49,7 +49,7 @@
       <span class="font-bold">{{ captcha_a }} + {{ captcha_b }} =</span>
       <input name="captcha_answer" required class="rounded-lg border px-3 py-1 w-24">
     </div>
-    <button class="mt-2 px-4 py-2 rounded-lg bg-neon-blue text-white">Submit Report</button>
+    <button class="mt-2 px-4 py-2 rounded-lg bg-brand-blue text-white hover:bg-brand-indigo transition-colors">Submit Report</button>
   </form>
 </section>
 {% endblock %}

--- a/templates/report_success.html
+++ b/templates/report_success.html
@@ -7,7 +7,7 @@
       <div><b>Case code:</b> <code>{{ token }}</code></div>
       <div><b>PIN:</b> <code>{{ pin }}</code></div>
     </div>
-    <a class="mt-4 inline-block px-4 py-2 rounded-lg bg-neutral-800 text-white" href="{{ url_for('follow') }}">Open case portal</a>
+    <a class="mt-4 inline-block px-4 py-2 rounded-lg bg-brand-blue text-white hover:bg-brand-indigo transition-colors" href="{{ url_for('follow') }}">Open case portal</a>
   </div>
 </section>
 {% endblock %}


### PR DESCRIPTION
## Summary
- Replace temporary neon scheme with a professional white/grey/blue brand palette in Tailwind config
- Restyle navigation, buttons, and portal links to use the new brand colors with subtle transitions
- Update dashboard charts and links to match palette for a cohesive look

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68adb888d9ec83289ed18af699f9753a