### PR TITLE
Allow manual assignment of reports to managers

### DIFF
--- a/templates/admin/report_detail.html
+++ b/templates/admin/report_detail.html
@@ -13,6 +13,15 @@
       </select>
       <button class="ml-2 px-3 py-2 rounded-lg bg-neutral-800 text-white">Update</button>
     </form>
+    <form method="post" class="mt-4">
+      <input type="hidden" name="action" value="assign_mgr">
+      <label class="block text-sm mb-1">Assign to manager</label>
+      <select name="manager_id" class="rounded-lg border px-3 py-2">
+        <option value="">Unassigned</option>
+        {% for m in managers %}<option value="{{ m.id }}" {% if r.manager_id==m.id %}selected{% endif %}>{{ m.email }}</option>{% endfor %}
+      </select>
+      <button class="ml-2 px-3 py-2 rounded-lg bg-neutral-800 text-white">Assign</button>
+    </form>
   </div>
   <div class="bg-white rounded-xl p-4 border shadow-glass">
     <div class="grid md:grid-cols-2 gap-4">

--- a/templates/admin/reports.html
+++ b/templates/admin/reports.html
@@ -15,13 +15,14 @@
 </form>
 <div class="bg-white rounded-xl p-4 border shadow-glass">
   <table class="w-full text-sm">
-    <tr class="text-left border-b"><th class="py-2">ID</th><th>Company</th><th>Category</th><th>Status</th><th>Created</th><th></th></tr>
+    <tr class="text-left border-b"><th class="py-2">ID</th><th>Company</th><th>Category</th><th>Status</th><th>Manager</th><th>Created</th><th></th></tr>
     {% for r in rows %}
       <tr class="border-b">
         <td class="py-2">{{ r.id }}</td>
         <td><code>{{ r.company_code }}</code></td>
         <td>{{ r.category }}</td>
         <td>{{ r.status }}</td>
+        <td>{{ r.manager_email or '—' }}</td>
         <td>{{ r.created_at[:19] }}</td>
         <td><a class="text-neon-blue" href="{{ url_for('admin_report_detail', rid=r.id) }}">Open</a></td>
       </tr>

--- a/tests/test_report_assignment.py
+++ b/tests/test_report_assignment.py
@@ -1,0 +1,44 @@
+import os, sys, importlib, pytest
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+import app
+
+admin_client = None
+manager_client = None
+
+
+@pytest.fixture(autouse=True)
+def fresh_db():
+    global app, admin_client, manager_client
+    if os.path.exists('carewhistle.db'):
+        os.remove('carewhistle.db')
+    importlib.reload(app)
+    admin_client = app.app.test_client()
+    manager_client = app.app.test_client()
+
+
+def login(client, email, password):
+    return client.post('/login', data={'email': email, 'password': password}, follow_redirects=True)
+
+def test_manager_sees_assigned_report():
+    login(admin_client, 'admin@admin.com', 'password')
+    db = app.get_db()
+    rid = db.execute('SELECT id FROM reports ORDER BY id LIMIT 1').fetchone()['id']
+    mid = db.execute("SELECT id FROM users WHERE role='manager' ORDER BY id LIMIT 1").fetchone()['id']
+    db.close()
+    admin_client.post(f'/admin/report/{rid}', data={'action': 'assign_mgr', 'manager_id': mid}, follow_redirects=True)
+    login(manager_client, 'manager@brightcare.com', 'manager1')
+    resp = manager_client.get('/manager/messages')
+    assert str(rid).encode() in resp.data
+
+
+def test_manager_does_not_see_unassigned_report():
+    login(admin_client, 'admin@admin.com', 'password')
+    db = app.get_db()
+    rid = db.execute('SELECT id FROM reports ORDER BY id LIMIT 1').fetchone()['id']
+    db.close()
+    login(manager_client, 'manager@brightcare.com', 'manager1')
+    resp = manager_client.get('/manager/messages')
+    html = resp.get_data(as_text=True)
+    assert f'<td class="py-2">{rid}</td>' not in html


### PR DESCRIPTION
## Summary
- add `manager_id` to reports and provide admin UI for assigning managers
- show manager assignments in admin report list
- restrict manager dashboards and messages to assigned reports
- avoid SQLite `RETURNING` conflicts by using `lastrowid` when inserting reports
- verify managers cannot access unassigned reports
- consolidate report insert logic to remove merge conflicts

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68adc5636e2c8328b56179b13fbf2cc6