### PR TITLE
feat: enable manual manager assignment for reports

### DIFF
--- a/templates/admin/report_detail.html
+++ b/templates/admin/report_detail.html
@@ -13,6 +13,15 @@
       </select>
       <button class="ml-2 px-3 py-2 rounded-lg bg-neutral-800 text-white">Update</button>
     </form>
+    <form method="post" class="mt-4">
+      <input type="hidden" name="action" value="assign">
+      <label class="block text-sm mb-1">Assign manager</label>
+      <select name="manager_id" class="rounded-lg border px-3 py-2">
+        <option value="">-- Unassigned --</option>
+        {% for m in managers %}<option value="{{ m.id }}" {% if r.manager_id==m.id %}selected{% endif %}>{{ m.email }}</option>{% endfor %}
+      </select>
+      <button class="ml-2 px-3 py-2 rounded-lg bg-neutral-800 text-white">Update</button>
+    </form>
   </div>
   <div class="bg-white rounded-xl p-4 border shadow-glass">
     <div class="grid md:grid-cols-2 gap-4">


### PR DESCRIPTION
## Summary
- add `manager_id` to reports and enforce manager-specific views
- allow admins to assign reports to managers through the UI
- test that managers only see reports after assignment

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b1b3d8bb1883288ef55ad120abadf5